### PR TITLE
add alignment test

### DIFF
--- a/tests/testthat/test-200-alignment.R
+++ b/tests/testthat/test-200-alignment.R
@@ -1,0 +1,42 @@
+test_that("Simple alignment completes without error", {
+
+  regimens <- ARTEMIS::loadRegimens(condition = "all")
+  regGroups <- ARTEMIS::loadGroups()
+  validDrugs <- ARTEMIS::loadDrugs()
+
+  # Use the first known regimen and repeat it 3 times
+  test_seq <- regimens$shortString[1]
+  repeated_seq <- paste0(rep(test_seq, 3), collapse = "")
+
+  df <- data.frame(
+    person_id = "test",
+    seq = repeated_seq,
+    stringsAsFactors = FALSE
+  )
+
+  # Generate raw alignment
+  output_all <- df %>%
+    generateRawAlignments(
+      regimens = regimens,
+      g = 0.4,
+      Tfac = 0.4,
+      method = "PropDiff",
+      verbose = 0
+    )
+
+  # Process alignment
+  processedAll <- output_all %>%
+    processAlignments(
+      regimens = regimens,
+      regimenCombine = 28
+    )
+
+  pa <- processedAll %>%
+    calculateEras()
+
+  # Expectation: alignment correctly maps back to the original regimen
+  expect_true(
+    all(pa$component == regimens$regName[1]),
+    info = "Alignment did not return expected original regimen"
+  )
+})


### PR DESCRIPTION
new test results:

devtools::test(pkg = "/home/ss/proj/ARTEMIS")
ℹ Testing ARTEMIS
[ARTEMIS-boot-R] Setup env...
[ARTEMIS-boot-R] Initializing Python backend...
Using Python: /usr/bin/python
Creating virtual environment '/home/ss/proj/ARTEMIS/inst/.r-reticulate' ... 
+ /usr/bin/python -m venv /home/ss/proj/ARTEMIS/inst/.r-reticulate
Done!
Installing packages: pip, wheel, setuptools
+ /home/ss/proj/ARTEMIS/inst/.r-reticulate/bin/python -m pip install --upgrade pip wheel setuptools
Requirement already satisfied: pip in ./inst/.r-reticulate/lib/python3.13/site-packages (25.3)
Collecting wheel
  Using cached wheel-0.45.1-py3-none-any.whl.metadata (2.3 kB)
Collecting setuptools
  Using cached setuptools-80.9.0-py3-none-any.whl.metadata (6.6 kB)
Using cached wheel-0.45.1-py3-none-any.whl (72 kB)
Using cached setuptools-80.9.0-py3-none-any.whl (1.2 MB)
Installing collected packages: wheel, setuptools
Successfully installed setuptools-80.9.0 wheel-0.45.1
Installing packages: numpy
+ /home/ss/proj/ARTEMIS/inst/.r-reticulate/bin/python -m pip install --upgrade --no-user numpy
Collecting numpy
  Using cached numpy-2.3.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl.metadata (62 kB)
Using cached numpy-2.3.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl (16.6 MB)
Installing collected packages: numpy
Successfully installed numpy-2.3.5
Virtual environment '/home/ss/proj/ARTEMIS/inst/.r-reticulate' successfully created.
[ARTEMIS-boot-Py] Detected OS: linux
[ARTEMIS-boot-Py] Architecture: x86_64
[ARTEMIS-boot-Py] Host Python: 3.13.11
[ARTEMIS-boot-Py] Reusing existing build environment at /home/ss/proj/ARTEMIS/.Ruserdata-ARTEMIS/ARTEMIS/.r-reticulate
[ARTEMIS-boot-Py] Already built. Skipping rebuild.
[ARTEMIS-boot-Py] [OK] Build completed.
[ARTEMIS-boot-R] [OK] align_patients_regimens loaded (cython)
✔ | F W  S  OK | Context
✔ |          1 | 000-smoke                                                      
Processing patients: 100%|███████████████████████| 1/1 [00:00<00:00, 767.48it/s]
Cython module loaded successfully.
Processing patients: 100%|██████████████████████| 1/1 [00:00<00:00, 1527.42it/s]
Cython module loaded successfully.
✔ |          1 | 100-bridge
Processing patients: 100%|███████████████████████| 1/1 [00:00<00:00, 192.53it/s]
i Performing post-processing of 1 patients.
 Total alignments: 10
[==================================================] 1 / 1
i Regimen cycle length data not detected as input...
v Complete!
✔ |          1 | 200-alignment

══ Results ═════════════════════════════════════════════════════════════════════
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 3 ]
Warning message:
Previous request to `use_python("/home/ss/proj/ARTEMIS/.Ruserdata-ARTEMIS/ARTEMIS/.r-reticulate/bin/python", required = TRUE)` will be ignored. It is superseded by request to `use_python("/home/ss/proj/ARTEMIS/inst/.r-reticulate/bin/python") 
